### PR TITLE
Allow GitHub CodeSpaces to use prefixed localstorage keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,21 +33,31 @@ const loadPromise = localforage.ready()
     };
   });
 
+const trusted = /^127\.0\.0\.1(?::|$)|localhost(?::|$)|(?:app\.|local\.)?webaverse\.com|webaverse\.link/
+const github = /github\.dev$/
+
 const _message = e => {
   const url = new URL(e.origin);
-  if (url && /^127\.0\.0\.1(?::|$)|localhost(?::|$)|(?:app\.|local\.)?webaverse\.com|webaverse\.link/.test(url.host)) {
+  const gh = github.test(url.host)
+  const allowed = trusted.test(url.host) || gh
+
+  if (url && allowed) {
     const j = e.data;
     if (j && j._localstorage && j.port) {
       const {port} = j;
       port.onmessage = async e => {
         const localforage = await loadPromise;
 
+        const prefix = gh ? `${url.host}-` : ""
+
         // console.log('localstorage request', e.data);
         const j = e.data;
         const {method, id} = j;
+        const key = `${prefix}${j.key}`
+
         switch (method) {
           case 'get': {
-            const {key} = j;
+        
             const s = await localforage.getItem(key);
             const result = typeof s === 'string' ? JSON.parse(s) : null;
             // console.log('localstorage response', e.data, result);
@@ -58,7 +68,7 @@ const _message = e => {
             break;
           }
           case 'set': {
-            const {key, value} = j;
+            const {value} = j;
             await localforage.setItem(key, JSON.stringify(value));
             const result = null;
             // console.log('localstorage response', e.data, result);
@@ -69,7 +79,6 @@ const _message = e => {
             break;
           }
           case 'remove': {
-            const {key} = j;
             const s = await localforage.removeItem(key);
             const result = null;
             // console.log('localstorage response', e.data, result);

--- a/index.html
+++ b/index.html
@@ -33,13 +33,13 @@ const loadPromise = localforage.ready()
     };
   });
 
-const trusted = /^127\.0\.0\.1(?::|$)|localhost(?::|$)|(?:app\.|local\.)?webaverse\.com|webaverse\.link/
-const github = /githubpreview\.dev$/
+const trusted = /^127\.0\.0\.1(?::|$)|localhost(?::|$)|(?:app\.|local\.)?webaverse\.com|webaverse\.link/;
+const github = /\.githubpreview\.dev$/;
 
 const _message = e => {
   const url = new URL(e.origin);
-  const gh = github.test(url.host)
-  const allowed = trusted.test(url.host) || gh
+  const gh = github.test(url.host);
+  const allowed = trusted.test(url.host) || gh;
 
   if (url && allowed) {
     const j = e.data;
@@ -48,7 +48,7 @@ const _message = e => {
       port.onmessage = async e => {
         const localforage = await loadPromise;
 
-        const prefix = gh ? `${url.host}-` : ""
+        const prefix = gh ? `${url.host}-` : "";
 
         // console.log('localstorage request', e.data);
         const j = e.data;

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ const loadPromise = localforage.ready()
   });
 
 const trusted = /^127\.0\.0\.1(?::|$)|localhost(?::|$)|(?:app\.|local\.)?webaverse\.com|webaverse\.link/
-const github = /github\.dev$/
+const github = /githubpreview\.dev$/
 
 const _message = e => {
   const url = new URL(e.origin);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/462380/129629291-e603077a-ef46-4eb8-a308-57ad3a21a449.png)
Tested by updating constants.js 

`export const localstorageHost = 'https://agoblinking-webaverse-localstorage-r4r76j52wpr9-8080.githubpreview.dev/';`

And running a static webserver on the localstorage codespace. 

